### PR TITLE
Migrated to API v2!

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ LANGUAGES = [
     {'name': 'HTML, CSS, JS', 'icon': 'images/langs/html.png', 'key': 'html'},
     {'name': 'Java', 'icon': 'images/langs/java.png', 'key': 'java'},
     {'name': 'Javascript', 'icon': 'images/langs/js.png', 'key': 'js'},
-    {'name': 'NodeJS', 'icon': 'images/langs/node.png', 'key': 'node'},
+    {'name': 'NodeJS', 'icon': 'images/langs/node.png', 'key': 'nodejs'},
     {'name': 'PHP', 'icon': 'images/langs/php.png', 'key': 'php'},
     {'name': 'Python', 'icon': 'images/langs/python.png', 'key': 'python'},
     {'name': 'Ruby', 'icon': 'images/langs/ruby.png', 'key': 'ruby'},

--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,19 @@
 {
-    "manifest_version": "2",
-    "api_version": "1",
-    "name": "Repl.it",
-    "description": "Provides Quick access to repl.it service for multiple languages",
-    "developer_name": "Bruno Paz",
-    "icon": "images/icon.png",
-    "options": {
-        "query_debounce": 0.2
-    },
-    "preferences": [{
-        "id": "demo_kw",
-        "type": "keyword",
-        "name": "Repl",
-        "description": "Repl extension",
-        "default_value": "repl"
-    }]
+  "required_api_version": "^2.0.0",
+  "name": "Repl.it",
+  "description": "Provides Quick access to repl.it service for multiple languages",
+  "developer_name": "Bruno Paz",
+  "icon": "images/icon.png",
+  "options": {
+    "query_debounce": 0.2
+  },
+  "preferences": [
+    {
+      "id": "demo_kw",
+      "type": "keyword",
+      "name": "Repl",
+      "description": "Repl extension",
+      "default_value": "repl"
+    }
+  ]
 }

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "api-v1-release" },
+  { "required_api_version": "^2.0.0", "commit": "master" }
+]


### PR DESCRIPTION
I've added branch api-v1-release, as per ulaunchers migration guide. It's identical to the previous master (API v1).
Please do a git fetch git@github.com:therj/ulauncher-repl.git api-v1-release:api-v1-release.